### PR TITLE
fix(wkhtmltopdf-broken)

### DIFF
--- a/lib/capistrano/ops/version.rb
+++ b/lib/capistrano/ops/version.rb
@@ -2,6 +2,6 @@
 
 module Capistrano
   module Ops
-    VERSION = '1.0.1'
+    VERSION = '1.0.2'
   end
 end

--- a/lib/capistrano/ops/wkhtmltopdf/helpers.rb
+++ b/lib/capistrano/ops/wkhtmltopdf/helpers.rb
@@ -2,48 +2,50 @@
 
 module Capistrano
   module Ops
-    module Helper
-      def binary_path
-        gem_path = capture(:bundle, 'show', 'wkhtmltopdf-binary').strip
-        "#{gem_path}/bin"
-      end
+    module Wkhtmltopdf
+      module Helpers
+        def binary_path
+          gem_path = capture(:bundle, 'show', 'wkhtmltopdf-binary').strip
+          "#{gem_path}/bin"
+        end
 
-      def gem_version
-        capture(:cat, 'config/initializers/wicked_pdf.rb').scan(/wkhtmltopdf_ubuntu_(\d+\.\d+)_amd64/).flatten.first
-      end
+        def gem_version
+          capture(:cat, 'config/initializers/wicked_pdf.rb').scan(/wkhtmltopdf_ubuntu_(\d+\.\d+)_amd64/).flatten.first
+        end
 
-      def binary_path_and_version
-        [binary_path, gem_version]
-      end
+        def binary_path_and_version
+          [binary_path, gem_version]
+        end
 
-      def file_existing?(file)
-        test("[ -f #{file} ]")
-      end
+        def file_existing?(file)
+          test("[ -f #{file} ]")
+        end
 
-      def right_permissions?(file)
-        test("[ $(stat -c '%a' #{file}) = '777' ]")
-      end
+        def right_permissions?(file)
+          test("[ $(stat -c '%a' #{file}) = '777' ]")
+        end
 
-      def check_file_and_permissions(binary_path, version)
-        binary_file = "#{binary_path}/wkhtmltopdf_ubuntu_#{version}_amd64"
+        def check_file_and_permissions(binary_path, version)
+          binary_file = "#{binary_path}/wkhtmltopdf_ubuntu_#{version}_amd64"
 
-        if file_existing?(binary_file)
-          info('wkhtmltopdf binary already extracted')
+          if file_existing?(binary_file)
+            info('wkhtmltopdf binary already extracted')
 
-          if right_permissions?(binary_file)
-            info('wkhtmltopdf binary has already the right permissions')
+            if right_permissions?(binary_file)
+              info('wkhtmltopdf binary has already the right permissions')
+            else
+              info('adding right permissions to wkhtmltopdf binary')
+              execute("chmod 777 #{binary_file}")
+            end
           else
-            info('adding right permissions to wkhtmltopdf binary')
+            info('extracting wkhtmltopdf binary')
+            # extract the binary but keep the gzip file
+            execute("cd #{binary_path} && gzip -dk  wkhtmltopdf_ubuntu_#{version}_amd64.gz")
+            # add execute permission to the binary
             execute("chmod 777 #{binary_file}")
           end
-        else
-          info('extracting wkhtmltopdf binary')
-          # extract the binary but keep the gzip file
-          execute("cd #{binary_path} && gzip -dk  wkhtmltopdf_ubuntu_#{version}_amd64.gz")
-          # add execute permission to the binary
-          execute("chmod 777 #{binary_file}")
+          info('wkhtmltopdf setup finished')
         end
-        info('wkhtmltopdf setup finished')
       end
     end
   end


### PR DESCRIPTION
* add missing declarations for Capistrano::Ops::Wkhtmltopdf::Helpers
* bump version to 1.0.2
