### PR TITLE
fix(figaro_yml-losing-stage-local): Update configs helper to retain other stages locally

### DIFF
--- a/lib/capistrano/ops/figaro_yml/tasks/compare.rake
+++ b/lib/capistrano/ops/figaro_yml/tasks/compare.rake
@@ -10,12 +10,12 @@ namespace :figaro_yml do
     local = local_figaro_yml(figaro_yml_env)
 
     # Split into stage-specific and global configurations
-    local_global_env, local_stage_env = configs(local, figaro_yml_env)
+    local_global_env, local_stage_env, _local_rest = configs(local, figaro_yml_env)
 
     on release_roles :all do
       # Read and parse remote application.yml
       remote = YAML.safe_load(capture("cat #{figaro_yml_remote_path}"))
-      remote_global_env, remote_stage_env = configs(remote, figaro_yml_env)
+      remote_global_env, remote_stage_env, _remote_rest = configs(remote, figaro_yml_env)
 
       # Compare hashes and handle nil results with empty hashes
       differences_global = compare_hashes(local_global_env, remote_global_env)

--- a/lib/capistrano/ops/version.rb
+++ b/lib/capistrano/ops/version.rb
@@ -2,6 +2,6 @@
 
 module Capistrano
   module Ops
-    VERSION = '1.0.3'
+    VERSION = '1.0.4'
   end
 end


### PR DESCRIPTION
- Update configs helper to return the rest of `application.yml` as the third element.
- Implement changes to ensure that the other stages are kept locally.
- Bump Capistrano::Ops version to 1.0.4 to mark the introduction of the above enhancements.

This set of changes aims to maintain the integrity of other stages in the local `application.yml` configuration.

This commit message was written by VSCode Copilot.
