### PR TITLE
fix(s3-stream-upload-backup): Update S3 upload to allow streaming directly into tar.gz file

### DIFF
--- a/capistrano-ops.gemspec
+++ b/capistrano-ops.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.required_ruby_version = '>= 2.7.0', '< 3.3.0'
-  s.add_dependency 'aws-sdk-s3', '~> 1.128'
+  s.add_dependency 'aws-sdk-s3', '~> 1.175'
   s.add_dependency 'faraday'
   s.add_dependency 'nokogiri'
   s.add_dependency 'rails'

--- a/lib/capistrano/ops/rails/lib/backup/api.rb
+++ b/lib/capistrano/ops/rails/lib/backup/api.rb
@@ -9,11 +9,11 @@ module Backup
       self.provider_config = provider_config
     end
 
-    def upload(backup_file, filename)
+    def upload(backup_file, filename, type = 'file')
       case backup_provider
       when 's3'
         s3 = Backup::S3.new(**provider_config)
-        s3.upload(backup_file, filename)
+        s3.upload_stream(backup_file, filename, type)
       when 'scp'
         p 'SCP backup not implemented yet'
       when 'rsync'

--- a/lib/capistrano/ops/rails/lib/backup/s3.rb
+++ b/lib/capistrano/ops/rails/lib/backup/s3.rb
@@ -2,10 +2,13 @@
 
 module Backup
   require 'aws-sdk-s3'
+  require 'rubygems/package'
+  require 'zlib'
+  require 'find'
   require 'capistrano/ops/rails/lib/backup/s3_helper'
   class S3
     include Backup::S3Helper
-    attr_accessor :endpoint, :region, :access_key_id, :secret_access_key, :s3_resource
+    attr_accessor :endpoint, :region, :access_key_id, :secret_access_key, :s3_resource, :s3_client
 
     def initialize(endpoint: ENV['S3_BACKUP_ENDPOINT'], region: ENV['S3_BACKUP_REGION'], access_key_id: ENV['S3_BACKUP_KEY'],
                    secret_access_key: ENV['S3_BACKUP_SECRET'])
@@ -22,6 +25,7 @@ module Backup
       }
       configuration[:endpoint] = endpoint unless endpoint.nil?
       self.s3_resource = Aws::S3::Resource.new(configuration)
+      self.s3_client = Aws::S3::Client.new(configuration)
     end
 
     def upload(backup_file, key)
@@ -32,6 +36,184 @@ module Backup
         raise e
       end
       'File uploaded to S3'
+    end
+
+    def upload_stream(backup_file, key, type)
+      if type == 'folder'
+        upload_folder_as_tar_gz_stream(backup_file, key)
+      else
+        upload_file_as_stream(backup_file, key)
+      end
+    end
+
+    def upload_file_as_stream(file_path, key)
+      bucket = ENV['S3_BACKUP_BUCKET']
+      # Calculate total size of the file to be uploaded
+      total_size = File.size(file_path)
+      chunk_size = calculate_chunk_size(total_size)
+
+      uploaded_size = 0
+
+      # Initiate multipart upload
+      multipart_upload = s3_client.create_multipart_upload(bucket: bucket, key: key)
+
+      # Upload the tar.gz data from the file in parts
+      part_number = 1
+      parts = []
+      last_logged_progress = 0
+
+      begin
+        File.open(file_path, 'rb') do |file|
+          while (part = file.read(chunk_size)) # Read calculated chunk size
+            part_upload = s3_client.upload_part(
+              bucket: bucket,
+              key: key,
+              upload_id: multipart_upload.upload_id,
+              part_number: part_number,
+              body: part
+            )
+            parts << { part_number: part_number, etag: part_upload.etag }
+            uploaded_size += part.size
+            part_number += 1
+
+            progress = (uploaded_size.to_f / total_size * 100).round
+            if progress >= last_logged_progress + 10
+              puts "Upload progress: #{progress}% complete"
+              last_logged_progress = progress
+            end
+          end
+        end
+
+        # Complete multipart upload
+        s3_client.complete_multipart_upload(
+          bucket: bucket,
+          key: key,
+          upload_id: multipart_upload.upload_id,
+          multipart_upload: { parts: parts }
+        )
+        puts 'Completed multipart upload'
+      rescue StandardError => e
+        # Abort multipart upload in case of error
+        s3_client.abort_multipart_upload(
+          bucket: bucket,
+          key: key,
+          upload_id: multipart_upload.upload_id
+        )
+        puts "Aborted multipart upload due to error: #{e.message}"
+        raise e
+      end
+
+      'File uploaded to S3 as tar.gz'
+    rescue StandardError => e
+      puts "Upload failed: #{e.message}"
+      raise e
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    def upload_folder_as_tar_gz_stream(folder_path, key)
+      bucket = ENV['S3_BACKUP_BUCKET']
+
+      # Calculate total size of the files to be uploaded
+      total_size = calculate_total_size(folder_path)
+      chunk_size = calculate_chunk_size(total_size)
+
+      # Create a pipe to stream data
+      read_io, write_io = IO.pipe
+      read_io.binmode
+      write_io.binmode
+
+      uploaded_size = 0
+
+      # Start a thread to write the tar.gz data to the pipe
+      writer_thread = start_writer_thread(folder_path, write_io)
+
+      # Initiate multipart upload
+      multipart_upload = s3_client.create_multipart_upload(bucket: bucket, key: key)
+
+      # Upload the tar.gz data from the pipe in parts
+      part_number = 1
+      parts = []
+      last_logged_progress = 0
+
+      begin
+        while (part = read_io.read(chunk_size)) # Read calculated chunk size
+          part_upload = s3_client.upload_part(
+            bucket: bucket,
+            key: key,
+            upload_id: multipart_upload.upload_id,
+            part_number: part_number,
+            body: part
+          )
+          parts << { part_number: part_number, etag: part_upload.etag }
+          uploaded_size += part.size
+          part_number += 1
+
+          progress = (uploaded_size.to_f / total_size * 100).round
+          if progress >= last_logged_progress + 10
+            puts "Upload progress: #{progress}% complete"
+            last_logged_progress = progress
+          end
+        end
+
+        # Complete multipart upload
+        s3_client.complete_multipart_upload(
+          bucket: bucket,
+          key: key,
+          upload_id: multipart_upload.upload_id,
+          multipart_upload: { parts: parts }
+        )
+        puts 'Completed multipart upload'
+      rescue StandardError => e
+        # Abort multipart upload in case of error
+        s3_client.abort_multipart_upload(
+          bucket: bucket,
+          key: key,
+          upload_id: multipart_upload.upload_id
+        )
+        puts "Aborted multipart upload due to error: #{e.message}"
+        raise e
+      ensure
+        read_io.close unless read_io.closed?
+        writer_thread.join
+      end
+
+      'Folder uploaded to S3 as tar.gz'
+    rescue StandardError => e
+      puts "Upload failed: #{e.message}"
+      raise e
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    def start_writer_thread(folder_path, write_io)
+      Thread.new do
+        parent_folder = File.dirname(folder_path)
+        folder_name = File.basename(folder_path)
+
+        Zlib::GzipWriter.wrap(write_io) do |gz|
+          Gem::Package::TarWriter.new(gz) do |tar|
+            Dir.chdir(parent_folder) do
+              Find.find(folder_name) do |file_path|
+                if File.directory?(file_path)
+                  tar.mkdir(file_path, File.stat(file_path).mode)
+                else
+                  mode = File.stat(file_path).mode
+                  tar.add_file_simple(file_path, mode, File.size(file_path)) do |tar_file|
+                    File.open(file_path, 'rb') do |f|
+                      while (chunk = f.read(1024 * 1024)) # Read in 1MB chunks
+                        tar_file.write(chunk)
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      rescue StandardError => e
+        puts "Error writing tar.gz data: #{e.message}"
+      ensure
+        write_io.close unless write_io.closed?
+      end
     end
 
     def remove_old_backups(basename, keep: 5)

--- a/lib/capistrano/ops/rails/lib/backup/s3_helper.rb
+++ b/lib/capistrano/ops/rails/lib/backup/s3_helper.rb
@@ -21,5 +21,21 @@ module Backup
     def get_items_by_month(all_items, month)
       all_items.select { |item| item[:last_modified].strftime('%Y-%m') == month }
     end
+
+    def calculate_total_size(folder_path)
+      total_size = 0
+      Find.find(folder_path) do |file_path|
+        total_size += File.size(file_path) unless File.directory?(file_path)
+      end
+      total_size
+    end
+
+    def calculate_chunk_size(total_size)
+      max_chunks = 10_000
+      min_chunk_size = 20 * 1024 * 1024 # 20MB
+      max_chunk_size = 105 * 1024 * 1024 # 105MB
+      chunk_size = [total_size / max_chunks, min_chunk_size].max
+      [chunk_size, max_chunk_size].min
+    end
   end
 end

--- a/lib/capistrano/ops/rails/lib/tasks/pg/dump.rake
+++ b/lib/capistrano/ops/rails/lib/tasks/pg/dump.rake
@@ -5,9 +5,12 @@ namespace :pg do
   include PostgresHelper
 
   task :dump do
-    backup_path = configuration[:backup_path]
-    backups_enabled = configuration[:backups_enabled]
-    external_backup = configuration[:external_backup]
+    backup_path = config[:backup_path]
+    backups_enabled = config[:backups_enabled]
+    external_backup = config[:external_backup]
+    database = config[:database]
+    date = Time.now.to_i
+    filename = "#{database}_#{date}.dump"
 
     unless backups_enabled
       puts 'dump: Backups are disabled'
@@ -15,26 +18,26 @@ namespace :pg do
     end
 
     notification = Notification::Api.new
-    commandlist = dump_cmd(configuration)
+    commandlist = dump_cmd(config)
 
     system "mkdir -p #{backup_path}" unless Dir.exist?(backup_path)
 
     result = system(commandlist)
 
     if ENV['BACKUP_PROVIDER'].present? && external_backup && result
-      puts "Uploading #{@filename} to #{ENV['BACKUP_PROVIDER']}..."
+      puts "Uploading #{filename} to #{ENV['BACKUP_PROVIDER']}..."
       provider = Backup::Api.new
       begin
-        provider.upload("#{@backup_path}/#{@filename}", @filename.to_s)
-        puts "#{@filename} uploaded to #{ENV['BACKUP_PROVIDER']}"
+        provider.upload("#{backup_path}/#{filename}", filename.to_s, 'file')
+        puts "#{filename} uploaded to #{ENV['BACKUP_PROVIDER']}"
       rescue StandardError => e
-        puts "#{@filename} upload failed: #{e.message}"
+        puts "#{filename} upload failed: #{e.message}"
       end
     end
-    notification.send_backup_notification(result, title, content(result, { database: @database, backup_path: @backup_path, filename: @filename }),
-                                          { date: @date, backup_path: @backup_path, database: @database })
-    puts result ? "Backup created: #{@backup_path}/#{@filename} (#{size_str(File.size("#{@backup_path}/#{@filename}"))})" : 'Backup failed removing dump file'
+    notification.send_backup_notification(result, title, content(result, { database: database, backup_path: backup_path, filename: filename }),
+                                          { date: date, backup_path: backup_path, database: database })
+    puts result ? "Backup created: #{backup_path}/#{filename} (#{size_str(File.size("#{backup_path}/#{filename}"))})" : 'Backup failed removing dump file'
 
-    system "rm #{@backup_path}/#{@filename}" unless result
+    system "rm #{backup_path}/#{filename}" unless result
   end
 end

--- a/lib/capistrano/ops/rails/lib/tasks/pg/postgres_helper.rb
+++ b/lib/capistrano/ops/rails/lib/tasks/pg/postgres_helper.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
 module PostgresHelper
-  def configuration
-    @configuration ||=
-      {
-        database: Rails.configuration.database_configuration[Rails.env]['database'],
-        username: Rails.configuration.database_configuration[Rails.env]['username'],
-        password: Rails.configuration.database_configuration[Rails.env]['password'],
-        hostname: Rails.configuration.database_configuration[Rails.env]['host'],
-        portnumber: Rails.configuration.database_configuration[Rails.env]['port'],
-        backup_path: Rails.root.join(Rails.env.development? ? 'tmp/backups' : '../../shared/backups').to_s,
-        backups_enabled: Rails.env.production? || ENV['BACKUPS_ENABLED'] == 'true',
-        external_backup: Rails.env.production? || ENV['EXTERNAL_BACKUP_ENABLED'] == 'true'
-      }
+  def config
+    @config ||= {
+      database: Rails.configuration.database_configuration[Rails.env]['database'],
+      username: Rails.configuration.database_configuration[Rails.env]['username'],
+      password: Rails.configuration.database_configuration[Rails.env]['password'],
+      hostname: Rails.configuration.database_configuration[Rails.env]['host'],
+      portnumber: Rails.configuration.database_configuration[Rails.env]['port'],
+      backup_path: Rails.root.join(Rails.env.development? ? 'tmp/backups' : '../../shared/backups').to_s,
+      backups_enabled: Rails.env.production? || ENV['BACKUPS_ENABLED'] == 'true',
+      external_backup: Rails.env.production? || ENV['EXTERNAL_BACKUP_ENABLED'] == 'true',
+      filename: "#{Rails.configuration.database_configuration[Rails.env]['database']}_#{Time.now.to_i}.dump"
+    }
   end
 
   def title
@@ -20,41 +20,41 @@ module PostgresHelper
   end
 
   def content(result, settings = {})
-    @database = settings[:database]
-    @backup_path = settings[:backup_path]
-    @filename = settings[:filename]
+    database = settings[:database]
+    backup_path = settings[:backup_path]
+    filename = settings[:filename]
 
     messages = []
     if result
-      messages << "Backup of #{@database} successfully finished at #{Time.now}"
-      messages << "Backup path:\`#{@backup_path}/#{@filename}\`"
+      messages << "Backup of #{database} successfully finished at #{Time.now}"
+      messages << "Backup path:\`#{backup_path}/#{filename}\`"
     else
-      messages << "Backup of #{@database} failed at #{Time.now}"
+      messages << "Backup of #{database} failed at #{Time.now}"
     end
     messages.join("\n")
   end
 
   def dump_cmd(settings = {})
-    @hostname = settings[:hostname]
-    @database = settings[:database]
-    @username = settings[:username]
-    @password = settings[:password]
-    @portnumber = settings[:portnumber]
-    @backup_path = settings[:backup_path]
+    hostname = settings[:hostname]
+    database = settings[:database]
+    username = settings[:username]
+    password = settings[:password]
+    portnumber = settings[:portnumber]
+    backup_path = settings[:backup_path]
 
-    @date = Time.now.to_i
+    date = Time.now.to_i
     options = []
-    options << " -d #{@database}" if @database.present?
-    options << " -U #{@username}" if @username.present?
-    options << " -h #{@hostname}" if @hostname.present?
-    options << " -p #{@portnumber}" if @portnumber.present?
+    options << " -d #{database}" if database.present?
+    options << " -U #{username}" if username.present?
+    options << " -h #{hostname}" if hostname.present?
+    options << " -p #{portnumber}" if portnumber.present?
 
-    @filename = "#{@database}_#{@date}.dump"
+    filename = "#{database}_#{date}.dump"
 
     commandlist = []
-    commandlist << "export PGPASSWORD='#{@password}'"
-    commandlist << "cd #{@backup_path}"
-    commandlist << "pg_dump --no-acl --no-owner #{options.join('')} > #{@filename}"
+    commandlist << "export PGPASSWORD='#{password}'"
+    commandlist << "cd #{backup_path}"
+    commandlist << "pg_dump --no-acl --no-owner #{options.join('')} > #{filename}"
     commandlist.join(' && ')
   end
 

--- a/lib/capistrano/ops/rails/lib/tasks/storage/remove_old_backups.rake
+++ b/lib/capistrano/ops/rails/lib/tasks/storage/remove_old_backups.rake
@@ -8,8 +8,8 @@ namespace :storage do
   local_backup = Rails.env.production?
   local_backup = ENV['KEEP_LOCAL_STORAGE_BACKUPS'] == 'true' if ENV['KEEP_LOCAL_STORAGE_BACKUPS'].present?
 
-  @env_local_no = ENV['NUMBER_OF_LOCAL_BACKUPS'].present? ? ENV['NUMBER_OF_LOCAL_BACKUPS'] : nil
-  @env_external_no = ENV['NUMBER_OF_EXTERNAL_BACKUPS'].present? ? ENV['NUMBER_OF_EXTERNAL_BACKUPS'] : nil
+  @env_local_no = ENV['NUMBER_OF_LOCAL_BACKUPS'].presence
+  @env_external_no = ENV['NUMBER_OF_EXTERNAL_BACKUPS'].presence
   @total_local_backups_no = (@env_local_no || ENV['NUMBER_OF_BACKUPS'] || 7).to_i
   @total_external_backups_no = (@env_external_no || ENV['NUMBER_OF_BACKUPS'] || 7).to_i
   desc 'remove old storage backups'

--- a/lib/capistrano/ops/rails/lib/tasks/storage/storage_helper.rb
+++ b/lib/capistrano/ops/rails/lib/tasks/storage/storage_helper.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module StorageHelper
+  def configuration
+    @configuration ||=
+      {
+        backup_path: path_resolver('backups'),
+        storage_path: path_resolver('storage'),
+        backups_enabled: env_or_production('BACKUPS_ENABLED'),
+        external_backup: env_or_production('EXTERNAL_BACKUP_ENABLED'),
+        keep_local_backups: env_or_production('KEEP_LOCAL_STORAGE_BACKUPS'),
+        backup_provider: ENV['BACKUP_PROVIDER']
+      }
+  end
+
+  def title
+    ENV['DEFAULT_URL'] || "#{Rails.env} Backup"
+  end
+
+  def message(result = false, settings = {})
+    @backup_path = settings[:backup_path]
+    @filename = settings[:filename]
+    messages = []
+    if result
+      messages << "Backup of storage folder successfully finished at #{Time.now}"
+      messages << "Backup path:\`#{@backup_path}/#{@filename}\`"
+    else
+      messages << "Backup of storage folder failed at #{Time.now}"
+    end
+    messages.join("\n")
+  end
+
+  def backup_cmd(settings = {})
+    @backup_path = settings[:backup_path]
+    @date = Time.now.to_i
+    @filename = "storage_#{@date}.tar.gz"
+    FileUtils.mkdir_p(@backup_path) unless Dir.exist?(@backup_path)
+    "tar -zcf #{@backup_path}/#{@filename} -C #{settings[:storage_path]} ."
+  end
+
+  def size_str(size)
+    units = %w[B KB MB GB TB]
+    e = (Math.log(size) / Math.log(1024)).floor
+    s = format('%.2f', size.to_f / 1024**e)
+    s.sub(/\.?0*$/, units[e])
+  end
+
+  def create_local_backup(filename, storage_path, backup_path)
+    FileUtils.mkdir_p(backup_path) unless Dir.exist?(backup_path)
+    response = system(backup_cmd(backup_path: backup_path, storage_path: storage_path))
+    FileUtils.rm_rf("#{@backup_path}/#{filename}") unless response
+    puts response ? "Backup created: #{backup_path}/#{@filename} (#{size_str(File.size("#{@backup_path}/#{@filename}"))})" : 'Backup failed removing dump file'
+    response
+  end
+
+  private
+
+  def env_or_production(env_var, default: Rails.env.production?)
+    if ENV.key?(env_var)
+      ENV[env_var] == 'true'
+    else
+      default
+    end
+  end
+
+  def path_resolver(folder)
+    Rails.root.join(Rails.env.development? ? 'tmp' : '../../shared', folder).to_s
+  end
+end

--- a/lib/capistrano/ops/version.rb
+++ b/lib/capistrano/ops/version.rb
@@ -2,6 +2,6 @@
 
 module Capistrano
   module Ops
-    VERSION = '1.0.4'
+    VERSION = '1.0.5'
   end
 end


### PR DESCRIPTION
- Update S3 upload to allow streaming directly into tar.gz file.
- Update S3 upload to allow streaming for file.
- Refactor dump and backup tasks.
- Bump Capistrano::Ops version to 1.0.5 to mark the introduction of the above enhancements.

This set of changes aims to enhance the S3 upload functionality by allowing direct streaming into tar.gz files and streaming for individual files. Additionally, the dump and backup tasks have been refactored for improved readability and maintainability.

This commit message was written by VSCode Copilot.
