### PR TITLE
fix(retry-logic-s3-stream): Add retry logic to S3 uploads and bump version to v1.0.7

### DIFF
--- a/lib/capistrano/ops/version.rb
+++ b/lib/capistrano/ops/version.rb
@@ -2,6 +2,6 @@
 
 module Capistrano
   module Ops
-    VERSION = '1.0.7'
+    VERSION = '1.0.8'
   end
 end


### PR DESCRIPTION
- Bump version to v1.0.7
- Add retry logic to S3 uploads of backup to handle transient errors and ensure successful uploads.

This set of changes aims to improve the robustness of S3 uploads by adding retry logic with exponential backoff, ensuring that uploads can recover from transient errors and complete successfully.

This commit message was written by VSCode Copilot.
