### PR TITLE
fix(s3-multipart-missing-variable): Fix missing variables and update chunk size calculation, bump version to v1.0.9

### DIFF
--- a/lib/capistrano/ops/rails/lib/backup/s3.rb
+++ b/lib/capistrano/ops/rails/lib/backup/s3.rb
@@ -66,12 +66,12 @@ module Backup
       total_wait_time = 0
 
       begin
+        multipart_upload ||= s3_client.create_multipart_upload(bucket: bucket, key: key)
         File.open(file_path, 'rb') do |file|
           while (part = file.read(chunk_size)) # Read calculated chunk size
             retry_count = 0
             begin
               # Initiate multipart upload
-              multipart_upload ||= s3_client.create_multipart_upload(bucket: bucket, key: key)
               part_upload = s3_client.upload_part(
                 bucket: bucket,
                 key: key,
@@ -156,11 +156,11 @@ module Backup
       total_wait_time = 0
 
       begin
+        multipart_upload ||= s3_client.create_multipart_upload(bucket: bucket, key: key)
         while (part = read_io.read(chunk_size)) # Read calculated chunk size
           retry_count = 0
           begin
             # Initiate multipart upload
-            multipart_upload ||= s3_client.create_multipart_upload(bucket: bucket, key: key)
             part_upload = s3_client.upload_part(
               bucket: bucket,
               key: key,
@@ -224,8 +224,6 @@ module Backup
       raise e
     end
     # rubocop:enable Metrics/MethodLength
-
-    private
 
     def start_writer_thread(folder_path, write_io)
       Thread.new do

--- a/lib/capistrano/ops/rails/lib/backup/s3_helper.rb
+++ b/lib/capistrano/ops/rails/lib/backup/s3_helper.rb
@@ -32,7 +32,7 @@ module Backup
 
     def calculate_chunk_size(total_size)
       max_chunks = 10_000
-      min_chunk_size = 20 * 1024 * 1024 # 20MB
+      min_chunk_size = 50 * 1024 * 1024 # 50MB
       max_chunk_size = 105 * 1024 * 1024 # 105MB
       chunk_size = [total_size / max_chunks, min_chunk_size].max
       [chunk_size, max_chunk_size].min

--- a/lib/capistrano/ops/version.rb
+++ b/lib/capistrano/ops/version.rb
@@ -2,6 +2,6 @@
 
 module Capistrano
   module Ops
-    VERSION = '1.0.8'
+    VERSION = '1.0.9'
   end
 end


### PR DESCRIPTION
- Bump version to v1.0.9
- Fixed missing variables in S3 multipart upload.
- Updated calculation for chunks to ensure a minimum size of 50MB.

This set of changes aims to resolve issues with missing variables in the S3 multipart upload process and improve the efficiency of uploads by ensuring a minimum chunk size of 50MB.

---

This commit message was written by VSCode Copilot.
