### PR TITLE
feat(ruby-version-bump): Update required Ruby version to < 3.4.0, bump version to v1.0.9

### DIFF
--- a/capistrano-ops.gemspec
+++ b/capistrano-ops.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.7.0', '< 3.3.0'
+  s.required_ruby_version = '>= 2.7.0', '< 3.4.0'
   s.add_dependency 'aws-sdk-s3', '~> 1.175'
   s.add_dependency 'faraday'
   s.add_dependency 'nokogiri'

--- a/lib/capistrano/ops/rails/lib/backup/s3.rb
+++ b/lib/capistrano/ops/rails/lib/backup/s3.rb
@@ -56,8 +56,6 @@ module Backup
 
       uploaded_size = 0
 
-      # Initiate multipart upload
-
       # Upload the tar.gz data from the file in parts
       part_number = 1
       parts = []
@@ -156,11 +154,11 @@ module Backup
       total_wait_time = 0
 
       begin
+        # Initiate multipart upload
         multipart_upload ||= s3_client.create_multipart_upload(bucket: bucket, key: key)
         while (part = read_io.read(chunk_size)) # Read calculated chunk size
           retry_count = 0
           begin
-            # Initiate multipart upload
             part_upload = s3_client.upload_part(
               bucket: bucket,
               key: key,

--- a/lib/capistrano/ops/version.rb
+++ b/lib/capistrano/ops/version.rb
@@ -2,6 +2,6 @@
 
 module Capistrano
   module Ops
-    VERSION = '1.0.9'
+    VERSION = '1.0.10'
   end
 end


### PR DESCRIPTION
- Bump version to v1.0.10
- Updated required Ruby version to < 3.4.0

This set of changes aims to ensure compatibility with newer Ruby versions by updating the required Ruby version to be less than 3.4.0.

---

This commit message was written by VSCode Copilot.
